### PR TITLE
Replace PEAR Mail class with PHPMailer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Composer Dependencies
+composer.phar
+/vendor

--- a/Mail.class.php
+++ b/Mail.class.php
@@ -2,7 +2,8 @@
 
 use PHPMailer\PHPMailer\PHPMailer;
 
-include_once(__PATH__ . "/vendor/phpmailer/phpmailer/src/PHPMailer.php");
+include_once("./vendor/phpmailer/phpmailer/src/PHPMailer.php");
+include_once("./vendor/phpmailer/phpmailer/src/SMTP.php");
 
 /**
  * Mail Class
@@ -15,8 +16,8 @@ class Mail {
     private $useTLS = false;
     private $from_email = "noreply@melibraries.ca";
     private $from_name = "Me Libraries";
-    private $replyto_email = $this->from_email;
-    private $replyto_name = $this->from_name;
+    private $replyto_email = "noreply@melibraries.ca";
+    private $replyto_name = "Me Libraries";
 
     public $error_message = "";
 
@@ -43,8 +44,8 @@ class Mail {
 
         // configure mail recipients
         $mail->setFrom($this->from_email, $this->from_name);
-        $mail->setReplyTo($this->replyto_email, $this->replyto_name);
-        $mail->setAddress($to_email, $to_name);
+        $mail->addReplyTo($this->replyto_email, $this->replyto_name);
+        $mail->addAddress($to_email, $to_name);
 
         // configure mail content
         $mail->isHTML(true);

--- a/Mail.class.php
+++ b/Mail.class.php
@@ -1,0 +1,64 @@
+<?php
+
+use PHPMailer\PHPMailer\PHPMailer;
+
+include_once(__PATH__ . "/vendor/phpmailer/phpmailer/src/PHPMailer.php");
+
+/**
+ * Mail Class
+ * Utility class for sending emails via PHPMailer and EPL SMTP
+ */
+class Mail {
+
+    private $host = "smtp.epl.ca";
+    private $port = 25;
+    private $useTLS = false;
+    private $from_email = "noreply@melibraries.ca";
+    private $from_name = "Me Libraries";
+    private $replyto_email = $this->from_email;
+    private $replyto_name = $this->from_name;
+
+    /**
+     * Send Email
+     * 
+     * @param string $subject   The email's subject.
+     * @param string $body      The email's HTML content. 
+     * @param string $to_email  The recipient's email address. 
+     * @param string $to_name   The recipient's name.
+     * 
+     * @return bool Whether the email has been sent successfully.
+     */
+    public function send($subject, $body, $to_email, $to_name) {
+        
+        // initialize PHPMailer
+        $mail = new PHPMailer();
+
+        // configure mail server settings
+        $mail->isSMTP();
+        $mail->Host = $this->host;
+        $mail->SMTPAutoTLS = $this->useTLS;
+        $mail->Port = $this->port;
+
+        // configure mail recipients
+        $mail->setFrom($this->from_email, $this->from_name);
+        $mail->setReplyTo($this->replyto_email, $this->replyto_name);
+        $mail->setAddress($to_email, $to_name);
+
+        // configure mail content
+        $mail->isHTML(true);
+        $mail->Subject = $subject;
+        $mail->Body = $body;
+
+        // send the email
+        $sent = $mail->send();
+
+        // handle errors
+        if (!$sent) {
+            error_log("PHPMailer Error: {$mail->ErrorInfo}");
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/Mail.class.php
+++ b/Mail.class.php
@@ -18,6 +18,8 @@ class Mail {
     private $replyto_email = $this->from_email;
     private $replyto_name = $this->from_name;
 
+    public $error_message = "";
+
     /**
      * Send Email
      * 
@@ -55,6 +57,7 @@ class Mail {
         // handle errors
         if (!$sent) {
             error_log("PHPMailer Error: {$mail->ErrorInfo}");
+            $this->error_message = $mail->ErrorInfo;
             return false;
         }
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ This project is open source under the Apache License 2.0 and is
 copyright Edmonton Public Library, 2013.
 
 July 18, 2013
+
+## Installation
+
+This repository uses [Composer](https://getcomposer.org/) for dependency management. 
+
+Run `composer install` to install the required vendor libraries such as PHPMailer.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpmailer/phpmailer": "^6.5"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,84 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "90bbf95869b4e88bf0dc5022e708a458",
+    "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "a5b5c43e50b7fba655f793ad27303cd74c57363c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/a5b5c43e50b7fba655f793ad27303cd74c57363c",
+                "reference": "a5b5c43e50b7fba655f793ad27303cd74c57363c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "doctrine/annotations": "^1.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.5.6",
+                "yoast/phpunit-polyfills": "^0.2.0"
+            },
+            "suggest": {
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "stevenmaguire/oauth2-microsoft": "Needed for Microsoft XOAUTH2 authentication",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "time": "2021-06-16T14:33:43+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/join.php
+++ b/join.php
@@ -285,8 +285,7 @@ if ($result->num_rows > 0) {
 
 			
 			//Send an email to the customer if they have a valid email address
-			//JDL 2019-11-25 -  Set length from 5 to 599 to avoid emailing customers as email functionality is broken
-			if (strlen($_SESSION["customer"]["EMAIL"]) > 599) {
+			if (strlen($_SESSION["customer"]["EMAIL"]) > 5) {
 
 				$from = "Me Libaries <noreply@melibraries.ca>";
 				$to_email = $_SESSION["customer"]["EMAIL"];

--- a/join.php
+++ b/join.php
@@ -302,12 +302,18 @@ if ($result->num_rows > 0) {
 					$body .= "\n\nNote: Your PIN for ".$libraryComData["library_name"]." is different.\nIt has been set to ".$newNakedPin.".";
 				}
 
-				include_once("Mail.class.php");
-				$mail = new Mail();
-				$mail_sent = $mail->send($subject, $body, $to_email, $to_name);
+				try {
+					include_once("Mail.class.php");
+					$mail = new Mail();
+					$mail_sent = $mail->send($subject, $body, $to_email, $to_name);
+					$mail_error = $mail->error_message;
+				} catch (Exception $e) {
+					$mail_sent = false;
+					$mail_error = $e->getMessage();
+				}
 
 				if (!$mail_sent) {
-				  echo("<p>{$mail->error_message}</p>");
+				  echo("<p>$mail_error</p>");
 				} else {
 				  echo('<p>You have been sent an email about the following:</p>');
 				}

--- a/join.php
+++ b/join.php
@@ -287,10 +287,10 @@ if ($result->num_rows > 0) {
 			//Send an email to the customer if they have a valid email address
 			//JDL 2019-11-25 -  Set length from 5 to 599 to avoid emailing customers as email functionality is broken
 			if (strlen($_SESSION["customer"]["EMAIL"]) > 599) {
-				require_once "Mail.php";
 
 				$from = "Me Libaries <noreply@melibraries.ca>";
-				$to = $_SESSION["customer"]["FIRSTNAME"]." ".$_SESSION["customer"]["LASTNAME"]." <".$_SESSION["customer"]["EMAIL"].">";
+				$to_email = $_SESSION["customer"]["EMAIL"];
+				$to_name = $_SESSION["customer"]["FIRSTNAME"]." ".$_SESSION["customer"]["LASTNAME"];
 				$subject = 'You have joined '.$libraryComData["library_name"];
 				$body = "This is a friendly notice that the you now have joined ".$libraryComData["library_name"];
 				$body .= " and now have access to its collections with your home library card number!\n";
@@ -303,24 +303,11 @@ if ($result->num_rows > 0) {
 					$body .= "\n\nNote: Your PIN for ".$libraryComData["library_name"]." is different.\nIt has been set to ".$newNakedPin.".";
 				}
 
-				$host = "smtp.epl.ca";
+				include_once("Mail.class.php");
+				$mail_sent = Mail::send($subject, $body, $to_email, $to_name);
 
-				$headers = array (
-					'From' => $from,
-					'To' => $to,
-					'Subject' => $subject);
-					
-				$smtp = Mail::factory(
-					'smtp',
-					array (
-						'host' => $host,
-						'auth' => false)
-					);
-
-				$mail = $smtp->send($to, $headers, $body);
-
-				if (PEAR::isError($mail)) {
-				  echo("<p>" . $mail->getMessage() . "</p>");
+				if (!$mail_sent) {
+				  echo("<p>An error occured sending you an email about the following:</p>");
 				} else {
 				  echo('<p>You have been sent an email about the following:</p>');
 				}

--- a/join.php
+++ b/join.php
@@ -304,10 +304,11 @@ if ($result->num_rows > 0) {
 				}
 
 				include_once("Mail.class.php");
-				$mail_sent = Mail::send($subject, $body, $to_email, $to_name);
+				$mail = new Mail();
+				$mail_sent = $mail->send($subject, $body, $to_email, $to_name);
 
 				if (!$mail_sent) {
-				  echo("<p>An error occured sending you an email about the following:</p>");
+				  echo("<p>{$mail->error_message}</p>");
 				} else {
 				  echo('<p>You have been sent an email about the following:</p>');
 				}

--- a/testing/Mail.class.php
+++ b/testing/Mail.class.php
@@ -1,0 +1,67 @@
+<?php
+
+use PHPMailer\PHPMailer\PHPMailer;
+
+include_once(__PATH__ . "/../vendor/phpmailer/phpmailer/src/PHPMailer.php");
+
+/**
+ * Mail Class
+ * Utility class for sending emails via PHPMailer and EPL SMTP
+ */
+class Mail {
+
+    private $host = "smtp.epl.ca";
+    private $port = 25;
+    private $useTLS = false;
+    private $from_email = "noreply@melibraries.ca";
+    private $from_name = "Me Libraries";
+    private $replyto_email = $this->from_email;
+    private $replyto_name = $this->from_name;
+
+    public $error_message = "";
+
+    /**
+     * Send Email
+     * 
+     * @param string $subject   The email's subject.
+     * @param string $body      The email's HTML content. 
+     * @param string $to_email  The recipient's email address. 
+     * @param string $to_name   The recipient's name.
+     * 
+     * @return bool Whether the email has been sent successfully.
+     */
+    public function send($subject, $body, $to_email, $to_name) {
+        
+        // initialize PHPMailer
+        $mail = new PHPMailer();
+
+        // configure mail server settings
+        $mail->isSMTP();
+        $mail->Host = $this->host;
+        $mail->SMTPAutoTLS = $this->useTLS;
+        $mail->Port = $this->port;
+
+        // configure mail recipients
+        $mail->setFrom($this->from_email, $this->from_name);
+        $mail->setReplyTo($this->replyto_email, $this->replyto_name);
+        $mail->setAddress($to_email, $to_name);
+
+        // configure mail content
+        $mail->isHTML(true);
+        $mail->Subject = $subject;
+        $mail->Body = $body;
+
+        // send the email
+        $sent = $mail->send();
+
+        // handle errors
+        if (!$sent) {
+            error_log("PHPMailer Error: {$mail->ErrorInfo}");
+            $this->error_message = $mail->ErrorInfo;
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/testing/join.php
+++ b/testing/join.php
@@ -273,10 +273,10 @@ if ($result->num_rows > 0) {
 			//Send an email to the customer if they have a valid email address
 			//JDL: 2019-11-25 - Temporarily increase from 5 to 599 to avoid emailing while email is broken.
 			if (strlen($_SESSION["customer"]["EMAIL"]) > 599) {
-				require_once "Mail.php";
 
 				$from = "Me Libaries <noreply@melibraries.ca>";
-				$to = $_SESSION["customer"]["FIRSTNAME"]." ".$_SESSION["customer"]["LASTNAME"]." <".$_SESSION["customer"]["EMAIL"].">";
+				$to_email = $_SESSION["customer"]["EMAIL"];
+				$to_name = $_SESSION["customer"]["FIRSTNAME"]." ".$_SESSION["customer"]["LASTNAME"];
 				$subject = 'You have joined '.$libraryComData["library_name"];
 				$body = "This is a friendly notice that the you now have joined ".$libraryComData["library_name"];
 				$body .= " and now have access to its collections with your home library card number!\n";
@@ -289,24 +289,12 @@ if ($result->num_rows > 0) {
 					$body .= "\n\nNote: Your PIN for ".$libraryComData["library_name"]." is different.\nIt has been set to ".$newNakedPin.".";
 				}
 
-				$host = "smtp.epl.ca";
+				include_once("Mail.class.php");
+				$mail = new Mail();
+				$mail_sent = $mail->send($subject, $body, $to_email, $to_name);
 
-				$headers = array (
-					'From' => $from,
-					'To' => $to,
-					'Subject' => $subject);
-					
-				$smtp = Mail::factory(
-					'smtp',
-					array (
-						'host' => $host,
-						'auth' => false)
-					);
-
-				$mail = $smtp->send($to, $headers, $body);
-
-				if (PEAR::isError($mail)) {
-				  echo("<p>" . $mail->getMessage() . "</p>");
+				if (!$mail_sent) {
+					echo("<p>{$mail->error_message}</p>");
 				} else {
 				  echo('<p>You have been sent an email about the following:</p>');
 				}


### PR DESCRIPTION
Fix for #1 

* Implements [Composer](https://getcomposer.org/) for dependency management.
* Adds [PHPMailer](https://github.com/PHPMailer/PHPMailer) as a dependency.
* Adds new `Mail.class.php` to provide a centralized class for managing SMTP settings, and provides a simple interface for sending emails.
* Replaces usage of PEAR Mail class with the new PHPMailer-based Mail class.
* Duplicates all new changes into the `/testing` directory.

The addition of composer means that `composer install` must be run during the deployment/installation process. 